### PR TITLE
OCI runtime create failed: invalid mount 

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -417,7 +417,7 @@ const createDockerCompose = async (options) => {
             container_name: '$DATA_MIGRATIONS_HOST',
             depends_on: ['db'],
             volumes: [
-                'usr/src/data-migrations/node_modules',
+                '/usr/src/data-migrations/node_modules',
                 './data-migrations:/usr/src/data-migrations'
             ],
             env_file: ['.env']


### PR DESCRIPTION
ISSUE:
```
ERROR: for app-migrations-service  Cannot start service data-migrations: OCI runtime create failed: invalid mount {Destination:usr/src/data-migrations/node_modules Type:bind Source:/var/lib/docker/volumes/215b3ad887cabfe8d33485ab7f2e4fd36bb5b30149b1fb5892ea34e7a19fc2a8/_data Options:[rbind]}: mount destination usr/src/data-migrations/node_modules not absolute: unknown
```
